### PR TITLE
Remove ASCII encoding.

### DIFF
--- a/git_change/git.py
+++ b/git_change/git.py
@@ -301,11 +301,6 @@ def search_gerrit(query):
         if not line:
             continue
         result = simplejson.loads(line)
-        # Encode unicode value strings as ASCII. Otherwise the
-        # subprocess module has trouble with embedded NULL bytes.
-        for k, v in result.iteritems():
-            if hasattr(v, 'encode'):
-                result[k] = v.encode('ascii')
         if 'type' in result and result['type'] == 'stats':
             stats = result
         else:

--- a/git_change/version.py
+++ b/git_change/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.0'  # http://semver.org/
+__version__ = '0.2.1a'  # http://semver.org/


### PR DESCRIPTION
This breaks when there are non-ASCII characters in the
commit message(or branch name, or anything else we get back from
gerrit), and subprocess can now accept unicode objects containing
non-ASCII characters as part of the command. This does mean that
this version of git-change will probably not work for versions of
Python < 2.7.